### PR TITLE
Keyboard shortcuts fixed

### DIFF
--- a/untangled-2018/game/systems/userinputsystem.py
+++ b/untangled-2018/game/systems/userinputsystem.py
@@ -104,7 +104,8 @@ class UserInputSystem(System):
                         if activeSlot is not None:
                             entity[Inventory].activeSlot = activeSlot
                             if activeSlot in entity[Inventory].items.keys():
-                                entity[Inventory].activeItem = entity[Inventory].items[activeSlot]
+                                actItem = entity[Inventory].items[activeSlot]
+                                entity[Inventory].activeItem = (actItem["ID"], actItem["quantity"], actItem["sprite"], activeSlot)
 
 
                     if hoped_vel != (0, 0):


### PR DESCRIPTION
The active items were stored as dictionaries, instead of tuples when the
keyboard shortcuts were pressed